### PR TITLE
downgrade minimum perl version and set Type::Params minimum version

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -1,7 +1,7 @@
 use strict;
 use warnings;
 
-use 5.026001;
+use 5.024001;
 use ExtUtils::MakeMaker;
 # See lib/ExtUtils/MakeMaker.pm for details of how to influence
 # the contents of the Makefile that is written.
@@ -29,7 +29,7 @@ WriteMakefile(
 	'Sub::Retry'                      => 0,
 	'Tie::Hash'                       => 0,
 	'Time::Out'                       => 0,
-	'Type::Params'                    => 0,
+	'Type::Params'                    => 1.004004,
 	'Types::Standard'                 => 0,
 	'URI'                             => 0,
 	'URI::QueryParam'                 => 0,


### PR DESCRIPTION
all tests pass on perl 5.24.1 after updating Type::Params from 1.002001 to 1.004004, former version failed with:

    $ PERL5LIB=../Type-Tiny-1.002001/lib TEST_METHOD=tie perl -MCarp::Always -It/unit t/run_unit_some
    1..2
    ok 1 - use Google::RestApi::SheetsApi4::Worksheet;
    not ok 2 - worksheet (for test method 'tie') died (Can't locate object method "parents" via package "post_process" (perhaps you forgot to load "post_process"?) at ../Type-Tiny-1.002001/lib/Type/Params.pm line 307.