### PR TITLE
added support for google service accounts

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -34,6 +34,7 @@ WriteMakefile(
 	'Types::Standard'                 => 0,
 	'URI'                             => 0,
 	'URI::QueryParam'                 => 0,
+	'WWW::Google::Cloud::Auth::ServiceAccount' => 0,
 	'YAML::Any'                       => 0,
     },
     TEST_REQUIRES     => {

--- a/lib/Google/RestApi.pm
+++ b/lib/Google/RestApi.pm
@@ -33,19 +33,16 @@ sub new {
   my $class = shift;
 
   state $check = compile_named(
-    config_file          => Str, { optional => 1 },
-    _extra_              => slurpy Any,
+    config_file => Str, { optional => 1 },
+    _extra_     => slurpy Any,
   );
   my $self = named_extra($check->(@_));
-
 
   if ($self->{config_file}) {
     my $config = eval { LoadFile($self->{config_file}) };
     die "Unable to load config file '$self->{config_file}': $@" if $@;
     $self = Hash::Merge::merge($self, $config);
   }
-
-
 
   state $check2 = compile_named(
     config_file          => Str, { optional => 1 },

--- a/lib/Google/RestApi.pm
+++ b/lib/Google/RestApi.pm
@@ -19,9 +19,8 @@ use Type::Params qw(compile compile_named);
 use Types::Standard qw(Str StrMatch Int ArrayRef HashRef CodeRef slurpy Any);
 use URI;
 use URI::QueryParam;
-use YAML::Any qw(Dump LoadFile);
-
 use WWW::Google::Cloud::Auth::ServiceAccount;
+use YAML::Any qw(Dump LoadFile);
 
 use Google::RestApi::OAuth2;
 use Google::RestApi::Utils qw(named_extra);


### PR DESCRIPTION

to be used like this:
my $rest = Google::RestApi->new(
	service_account_file => '/path/to/service_account.json',
);

service accounts are practical because they act as different users and can be granted permissions just like real users. e.g. you as the owner have full access to all your stuff but a service account crated by you has no permissions at all unless granted. one can have several service accounts with different permissions.

I tried to adhere to your coding style as much as possible but you may want to perltidy it as I may have missed something.