### PR TITLE
Added support for multiple auth mechanisms and added service account …

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -34,6 +34,7 @@ WriteMakefile(
 	'Types::Standard'                 => 0,
 	'URI'                             => 0,
 	'URI::QueryParam'                 => 0,
+	'WWW::Google::Cloud::Auth::ServiceAccount' => 0,
 	'YAML::Any'                       => 0,
     },
     TEST_REQUIRES     => {

--- a/bin/google_restapi_session_creator
+++ b/bin/google_restapi_session_creator
@@ -1,7 +1,7 @@
 #!/usr/bin/perl
 
-# Script to get a web-based token that can be stored 
-# and used later to authorize our REST API access. 
+# Script to get a web-based token that can be stored and
+# used later to authorize our REST API access. 
 
 # Based on code from https://gist.github.com/hexaddikt/6738162
 
@@ -16,9 +16,11 @@
 # 3. Create a yaml file with the following format:
 #
 # ---
-# client_id: <client-id-from-google>
-# client_secret: <client-secret-from-google>
-# token_file: <file-name-to-store-your-generated-token>
+# auth:
+#   class: OAuth2Client
+#   client_id: <client-id-from-google>
+#   client_secret: <client-secret-from-google>
+#   token_file: <file-name-to-store-your-generated-token>
 #
 #    The token file will be stored in the same directory as
 #    the config file.
@@ -40,7 +42,7 @@
 #    that you should copy and paste back into the terminal
 #    window, so this script can exchange it for an access
 #    token from Google, and store the token. That wil be
-#    the the token the that this package can use.
+#    the token for this package.
 
 use FindBin;
 use lib "$FindBin::RealBin/../lib";
@@ -49,9 +51,10 @@ use File::Basename;
 use Storable;
 use Term::Prompt;
 use Type::Params qw(compile_named);
-use Types::Standard qw(Str);
+use Types::Standard qw(Str StrMatch);
 use YAML::Any qw(Dump LoadFile);
-use Google::RestApi::OAuth2;
+
+use Google::RestApi::Auth::OAuth2Client;
 
 # set the scope for the project you are working one.
 # for this package, drive and spreadsheets are required.
@@ -65,15 +68,16 @@ my $config = LoadFile($config_file);
 print "Config used:\n", Dump($config);
 
 my $check = compile_named(
+  class         => StrMatch[qr/^OAuth2Client$/],
   client_id     => Str,
   client_secret => Str,
   token_file    => Str,
 );
-$check->(%$config);
+$check->(%{ $config->{auth} });
 
-my $oauth2 = Google::RestApi::OAuth2->new(
-  client_id     => $config->{client_id},
-  client_secret => $config->{client_secret},
+my $oauth2 = Google::RestApi::Auth::OAuth2Client->new(
+  client_id     => $config->{auth}->{client_id},
+  client_secret => $config->{auth}->{client_secret},
   scope         => \@scope,
 );
 
@@ -124,7 +128,7 @@ print "Here are the token contents:\n\n";
 print $token->to_string(), "\n\n";
 
 # Save the token for future use:
-my $token_file = dirname($config_file) . "/$config->{token_file}";
+my $token_file = dirname($config_file) . "/$config->{auth}->{token_file}";
 store($token->session_freeze(), $token_file);
 
 print <<END2

--- a/lib/Google/RestApi.pm
+++ b/lib/Google/RestApi.pm
@@ -8,21 +8,19 @@ our $VERSION = '0.3';
 use 5.010_000;
 
 use autodie;
-use File::Basename;
 use Furl;
 use JSON;
-use Hash::Merge;
+use Scalar::Util qw(blessed);
 use Sub::Retry;
-use Storable qw(dclone retrieve);
+use Storable qw(dclone);
 use Time::Out qw(timeout);
 use Type::Params qw(compile compile_named);
-use Types::Standard qw(Str StrMatch Int ArrayRef HashRef CodeRef slurpy Any);
+use Types::Standard qw(Str StrMatch Int ArrayRef HashRef CodeRef);
 use URI;
 use URI::QueryParam;
-use YAML::Any qw(Dump LoadFile);
+use YAML::Any qw(Dump);
 
-use Google::RestApi::OAuth2;
-use Google::RestApi::Utils qw(named_extra);
+use Google::RestApi::Utils qw(config_file);
 
 no autovivification;
 
@@ -31,33 +29,15 @@ do 'Google/RestApi/logger_init.pl';
 sub new {
   my $class = shift;
 
+  my $self = config_file(@_);
   state $check = compile_named(
-    config_file => Str, { optional => 1 },
-    _extra_     => slurpy Any,
+    config_file  => Str, { optional => 1 },
+    auth         => 1,
+    post_process => CodeRef, { optional => 1 },
+    throttle     => Int->where('$_ > -1'), { default => 0 },
+    timeout      => Int, { default => 120 },
   );
-  my $self = named_extra($check->(@_));
-
-  if ($self->{config_file}) {
-    my $config = eval { LoadFile($self->{config_file}) };
-    die "Unable to load config file '$self->{config_file}': $@" if $@;
-    $self = Hash::Merge::merge($self, $config);
-  }
-
-  state $check2 = compile_named(
-    config_file   => Str, { optional => 1 },
-    client_id     => Str,
-    client_secret => Str,
-    token_file    => Str,
-    timeout       => Int, { default => 120 },
-    throttle      => Int->where('$_ > -1'), { default => 0 },
-    post_process  => CodeRef, { optional => 1 },
-  );
-  $self = $check2->(%$self);
-
-  $self->{token_file} = dirname($self->{config_file}) . "/$self->{token_file}"
-    if !-f $self->{token_file} && $self->{config_file};
-  die "Token file not found: '$self->{token_file}'"
-    if !-f $self->{token_file};
+  $self = $check->(%$self);
 
   return bless $self, $class;
 }
@@ -94,8 +74,10 @@ sub api {
   push(@headers, 'Content-Type' => 'application/json') if $content;
   push(@headers, @{ $p->{headers} });
 
+  # some (outdated) auth mechanisms may allow auth info in the params.
+  my %params = (%{ $p->{params} }, %{ $self->auth()->params() });
   $uri = URI->new($uri);
-  $uri->query_form_hash($p->{params});
+  $uri->query_form_hash(\%params);
   DEBUG("Rest API URI: $p->{method} ", $uri->as_string());
   my $req = HTTP::Request->new(
     $p->{method}, $uri->as_string(), \@headers,
@@ -163,7 +145,8 @@ sub _api {
 
   my $res = retry 3, 1.0,
     sub {
-      # timeout is in the ua too, but i've seen requests to spreadsheets completely hang.
+      # timeout is in the ua too, but i've seen requests to spreadsheets
+      # completely hang if the request isn't constructed correctly.
       timeout $self->{timeout} => sub {
         $self->ua()->request($req);
       };
@@ -186,42 +169,28 @@ sub _api {
 sub ua {
   my $self = shift;
   if (!$self->{ua}) {
-    my $access_token = $self->access_token();
     $self->{ua} = Furl->new(
-      headers => [ Authorization => "Bearer $access_token" ],
+      headers => $self->auth()->headers(),
       timeout => $self->{timeout},
     );
   }
   return $self->{ua};
 }
 
-sub access_token {
+sub auth {
   my $self = shift;
-  return $self->{access_token} if $self->{access_token};
 
-  state $check = compile_named(
-    scope => ArrayRef, { optional => 1 },
-  );
-  my $p = $check->(@_);
+  if (!blessed($self->{auth})) {
+    # turn OAuth2Client into Google::RestApi::Auth::OAuth2Client etc.
+    my $class = __PACKAGE__ . "::Auth::" . delete $self->{auth}->{class};
+    eval "require $class";
+    die "Unable to require '$class': $@" if $@;
+    $self->{auth}->{parent_config_file} = $self->{config_file}
+      if $self->{config_file};
+    $self->{auth} = $class->new(%{ $self->{auth} });
+  }
 
-  my $oauth2 = Google::RestApi::OAuth2->new(
-    client_id     => $self->{client_id},
-    client_secret => $self->{client_secret},
-    $p->{scope} ? (scope => $p->{scope}) : (),
-    #scope         => [qw(
-    #  https://www.googleapis.com/auth/drive
-    #  https://www.googleapis.com/auth/spreadsheets
-    #)],
-  );
-  $oauth2->access_token(
-    auto_refresh  => 1,
-    refresh_token => retrieve($self->{token_file})->{refresh_token},
-  );
-  $oauth2->refresh_token();
-  $self->{access_token} = $oauth2->access_token()->access_token();
-  INFO("Successfully attained access token");
-
-  return $self->{access_token};
+  return $self->{auth};
 }
 
 sub stats {
@@ -246,9 +215,7 @@ Google::RestApi - Connection to Google REST APIs (currently Drive and Sheets).
   use Google::RestApi;
   $rest_api = Google::RestApi->new(
     config_file   => <path_to_config_file>,
-    client_id     => <oauth2_client_id>,
-    client_secret => <oath2_secret>,
-    token_file    => <path_to_token_file>,
+    auth          => <object|hashref>,
     timeout       => <int>,
     throttle      => <int>,
     post_process  => <coderef>,
@@ -278,35 +245,41 @@ Google::RestApi - Connection to Google REST APIs (currently Drive and Sheets).
 =head1 DESCRIPTION
 
 Google Rest API is the foundation class used by the included Drive
-and Sheets APIs. It is used to establish an OAuth2 handshake, and
-send API requests to the Google API endpoint on behalf of the
-underlying API classes (Sheets and Drive).
-
-Once you have established the OAuth2 handshake, you would not
-use this class much, it would be used indirectly by the Drive/Sheets
-API classes.
+and Sheets APIs. It is used to send API requests to the Google API
+endpoint on behalf of the underlying API classes (Sheets and Drive).
 
 =head1 SUBROUTINES
 
 =over
 
-=item new(config_file => <path_to_config_file>, client_id => <str>, client_secret => <str>, token_file => <path_to_token_file>, post_process => <coderef>, throttle => <int>);
+=item new(config_file => <path_to_config_file>, auth => <object|hash>, post_process => <coderef>, throttle => <int>);
 
  config_file: Optional YAML configuration file that can specify any
    or all of the following args:
- client_id: The OAuth2 client id you got from Google.
- client_secret: The OAuth2 client secret you got from Google.
- token_file: The file path to the previously saved token (see OAUTH2
-   SETUP below). If a config_file is passed, the dirname of the config
-   file is tried to find the token_file (same directory) if only the
-   token file name is passed.
+ auth: A hashref to create the specified auth class, or (outside the config file) an instance of the blessed class itself.
  post_process: A coderef to call after each API call.
  throttle: Used in development to sleep the number of seconds
    specified between API calls to avoid threshhold errors from Google.
 
 You can specify any of the arguments in the optional YAML config file.
 Any passed in arguments will override what is in the config file.
-   
+
+The 'auth' arg can specify a pre-blessed class of one of the Google::RestApi::Auth::*
+classes, or, for convenience sake, you can specify a hash of the required
+arguments to create an instance of that class:
+  auth:
+    class: OAuth2Client
+    client_id: xxxxxx
+    client_secret: xxxxxx
+    token_file: <path_to_token_file>
+
+Note that the auth hash itself can also contain a config_file:
+  auth:
+    class: OAuth2Client
+    config_file: <path_to_oauth_config_file>
+
+This allows you the option to keep the auth file in a separate, more secure place.
+
 =item api(uri => <uri_string>, method => <http_method_string>,
   headers => <headers_string_array>, params => <query_parameters_hash>,
   content => <body_hash>);
@@ -331,13 +304,6 @@ Shows some statistics on how many get/put/post etc calls were made.
 Useful for performance tuning during development.
 
 =back
-
-=head1 OAUTH2 SETUP
-
-This class depends on first creating an OAuth2 token session file
-that you point to via the 'token_file' config param passed via 'new'.
-See bin/google_restapi_session_creator and follow the instructions to
-save your token file.
 
 =head1 SEE ALSO
 

--- a/lib/Google/RestApi/Auth.pm
+++ b/lib/Google/RestApi/Auth.pm
@@ -1,0 +1,36 @@
+package Google::RestApi::Auth;
+
+use strict;
+use warnings;
+
+our $VERSION = '0.3';
+
+use 5.010_000;
+
+use autodie;
+no autovivification;
+
+do 'Google/RestApi/logger_init.pl';
+
+sub params {{}}
+sub headers {[]};
+
+1;
+
+__END__
+
+=head1 NAME
+
+Google::RestApi::Auth - Base class for authorization for Google Rest APIs
+
+=head1 DESCRIPTION
+
+Small base class that establishes the contract between RestApi and the
+various possible authorization methods. If the auth class expects to be
+able to add a param to each URL (outdated), it will be called via 'params'
+when the time comes to add them to the calling URL. If the auth class
+expects to add an authorization header, it will be called via 'headers'
+to return the proper headers for that auth class.
+
+The default behaviour is to return nothing for each, so the base class
+has to return at least something for one of them to be functional.

--- a/lib/Google/RestApi/Auth.pm
+++ b/lib/Google/RestApi/Auth.pm
@@ -32,5 +32,5 @@ when the time comes to add them to the calling URL. If the auth class
 expects to add an authorization header, it will be called via 'headers'
 to return the proper headers for that auth class.
 
-The default behaviour is to return nothing for each, so the base class
+The default behaviour is to return nothing for each, so the derived class
 has to return at least something for one of them to be functional.

--- a/lib/Google/RestApi/Auth/OAuth2Client.pm
+++ b/lib/Google/RestApi/Auth/OAuth2Client.pm
@@ -12,7 +12,6 @@ our $VERSION = '0.3';
 use 5.010_000;
 
 use autodie;
-use File::Basename;
 use Net::OAuth2::Client;
 use Net::OAuth2::Profile::WebServer;
 use Storable qw(retrieve);
@@ -23,7 +22,7 @@ use YAML::Any qw(Dump);
 
 no autovivification;
 
-use Google::RestApi::Utils qw(config_file);
+use Google::RestApi::Utils qw(config_file resolve_config_file);
 
 use parent 'Google::RestApi::Auth';
 
@@ -144,22 +143,8 @@ sub oauth2_webserver {
 
 sub token_file {
   my $self = shift;
-  return $self->{_token_file} if $self->{_token_file};
-
-  # if token_file is a simple file name (no path) then assume it's in the
-  # same directory as the config_file. if this has been constructed by
-  # RestApi 'auth' hash, then that class would have stored its config
-  # file as 'parent_config_file' to resolve the token file here.
-  if (!-e $self->{token_file}) {
-    my $config_file = $self->{config_file} || $self->{parent_config_file};
-    $self->{token_file} = dirname($config_file) . "/$self->{token_file}"
-      if $config_file;
-  }
-
-  die "Token file not found or is not readable: '$self->{token_file}'"
-    if !-f -r $self->{token_file};
-
-  $self->{_token_file} = $self->{token_file};
+  $self->{_token_file} = resolve_config_file('token_file', $self)
+    if !$self->{_token_file};
   return $self->{_token_file};
 }
 

--- a/lib/Google/RestApi/Auth/ServiceAccount.pm
+++ b/lib/Google/RestApi/Auth/ServiceAccount.pm
@@ -8,7 +8,6 @@ our $VERSION = '0.3';
 use 5.010_000;
 
 use autodie;
-use File::Basename;
 use Type::Params qw(compile_named);
 use Types::Standard qw(Str ArrayRef);
 use WWW::Google::Cloud::Auth::ServiceAccount;
@@ -16,7 +15,7 @@ use YAML::Any qw(Dump);
 
 no autovivification;
 
-use Google::RestApi::Utils qw(config_file);
+use Google::RestApi::Utils qw(config_file resolve_config_file);
 
 use parent 'Google::RestApi::Auth';
 
@@ -61,22 +60,8 @@ sub access_token {
 
 sub account_file {
   my $self = shift;
-  return $self->{_account_file} if $self->{_account_file};
-
-  # if account_file is a simple file name (no path) then assume it's in the
-  # same directory as the config_file. if this has been constructed by
-  # RestApi 'auth' hash, then that class would have stored its config
-  # file as 'parent_config_file' to resolve the account file here.
-  if (!-e $self->{account_file}) {
-    my $config_file = $self->{config_file} || $self->{parent_config_file};
-    $self->{account_file} = dirname($config_file) . "/$self->{account_file}"
-      if $config_file;
-  }
-
-  die "Service account file not found or is not readable: '$self->{account_file}'"
-    if !-f -r $self->{account_file};
-
-  $self->{_account_file} = $self->{account_file};
+  $self->{_account_file} = resolve_config_file('account_file', $self)
+    if !$self->{_account_file};
   return $self->{_account_file};
 }
 

--- a/lib/Google/RestApi/Auth/ServiceAccount.pm
+++ b/lib/Google/RestApi/Auth/ServiceAccount.pm
@@ -1,0 +1,118 @@
+package Google::RestApi::Auth::ServiceAccount;
+
+use strict;
+use warnings;
+
+our $VERSION = '0.3';
+
+use 5.010_000;
+
+use autodie;
+use File::Basename;
+use Type::Params qw(compile_named);
+use Types::Standard qw(Str ArrayRef);
+use WWW::Google::Cloud::Auth::ServiceAccount;
+use YAML::Any qw(Dump);
+
+no autovivification;
+
+use Google::RestApi::Utils qw(config_file);
+
+use parent 'Google::RestApi::Auth';
+
+do 'Google/RestApi/logger_init.pl';
+
+sub new {
+  my $class = shift;
+
+  my $self = config_file(@_);
+  state $check = compile_named(
+    config_file        => Str, { optional => 1 },
+    parent_config_file => Str, { optional => 1 },  # only used internally
+    account_file       => Str,
+    scope              => ArrayRef[Str],
+  );
+  $self = $check->(%$self);
+
+  return bless $self, $class;
+}
+
+sub headers {
+  my $self = shift;
+  return $self->{headers} if $self->{headers};
+  my $access_token = $self->access_token();
+  $self->{headers} = [ Authorization => "Bearer $access_token" ];
+  return $self->{headers};
+}
+
+sub access_token {
+  my $self = shift;
+  return $self->{access_token} if $self->{access_token};
+
+  my $auth = WWW::Google::Cloud::Auth::ServiceAccount->new(
+    credentials_path => $self->account_file(),
+    # undocumented feature of WWW::Google::Cloud::Auth::ServiceAccount
+    scope            => join(' ', @{ $self->{scope} }),
+  );
+  $self->{access_token} = $auth->get_token()
+    or die "Service Account Auth failed";
+
+  return $self->{access_token};
+}
+
+sub account_file {
+  my $self = shift;
+  return $self->{_account_file} if $self->{_account_file};
+
+  # if account_file is a simple file name (no path) then assume it's in the
+  # same directory as the config_file. if this has been constructed by
+  # RestApi 'auth' hash, then that class would have stored its config
+  # file as 'parent_config_file' to resolve the account file here.
+  if (!-e $self->{account_file}) {
+    my $config_file = $self->{config_file} || $self->{parent_config_file};
+    $self->{account_file} = dirname($config_file) . "/$self->{account_file}"
+      if $config_file;
+  }
+
+  die "Service account file not found or is not readable: '$self->{account_file}'"
+    if !-f -r $self->{account_file};
+
+  $self->{_account_file} = $self->{account_file};
+  return $self->{_account_file};
+}
+
+1;
+
+__END__
+
+=head1 NAME
+
+Google::RestApi::Auth::ServiceAccount - Service Account support for Google Rest APIs
+
+=head1 SYNOPSIS
+
+  use Google::RestApi::Auth::ServiceAccount;
+
+  my $sa = Google::RestApi::Auth::ServiceAccount->new(
+    account_file => <path_to_account_json_file>,
+    scope        => ['http://spreadsheets.google.com/feeds/'],
+  );
+  # generate an access token from the code returned from Google:
+  my $token = $sa->access_token($code);
+
+=head1 AUTHOR
+
+Robin Murray E<lt>mvsjes@cpan.ork<gt>, copied and modifed from Net::Google::DataAPI::Auth::OAuth2.
+
+=head1 SEE ALSO
+
+L<OAuth2>
+
+L<Google::DataAPI::Auth::OAuth2>
+
+L<https://developers.google.com/accounts/docs/OAuth2> 
+
+=head1 LICENSE
+
+This library is free software; you can redistribute it and/or modify
+it under the same terms as Perl itself.

--- a/lib/Google/RestApi/Auth/ServiceAccount.pm
+++ b/lib/Google/RestApi/Auth/ServiceAccount.pm
@@ -102,13 +102,11 @@ Google::RestApi::Auth::ServiceAccount - Service Account support for Google Rest 
 
 =head1 AUTHOR
 
-Robin Murray E<lt>mvsjes@cpan.ork<gt>, copied and modifed from Net::Google::DataAPI::Auth::OAuth2.
+Robin Murray E<lt>mvsjes@cpan.ork<gt>.
 
 =head1 SEE ALSO
 
-L<OAuth2>
-
-L<Google::DataAPI::Auth::OAuth2>
+L<WWW::Google::Cloud::Auth::ServiceAccount>
 
 L<https://developers.google.com/accounts/docs/OAuth2> 
 

--- a/t/etc/rest_config.yaml
+++ b/t/etc/rest_config.yaml
@@ -1,4 +1,6 @@
 ---
-client_id: x
-client_secret: x
-token_file: rest_config.token
+auth:
+  class: OAuth2Client
+  client_id: x
+  client_secret: x
+  token_file: rest_config.token

--- a/t/integration/Google/restapi.t
+++ b/t/integration/Google/restapi.t
@@ -13,6 +13,7 @@ use Test::Most tests => 4;
 
 use Utils;
 use aliased "Google::RestApi";
+use Google::RestApi::Auth::OAuth2Client;
 
 Utils::init_logger();
 

--- a/t/integration/Utils.pm
+++ b/t/integration/Utils.pm
@@ -45,8 +45,8 @@ sub sheets_api {
 }
 
 sub rest_api_config {
-  my $config_file = $ENV{GOOGLE_RESTAPI_LOGIN}
-    or die "No testing config file found: set env var GOOGLE_RESTAPI_LOGIN first";
+  my $config_file = $ENV{GOOGLE_RESTAPI_CONFIG}
+    or die "No testing config file found: set env var GOOGLE_RESTAPI_CONFIG first";
   return $config_file;
 }
 

--- a/t/unit/Test/Google/RestApi.pm
+++ b/t/unit/Test/Google/RestApi.pm
@@ -1,7 +1,9 @@
 package Test::Google::RestApi;
 
 use FindBin;
+use Storable qw(dclone);
 use Test::Most;
+
 use parent 'Test::Class';
 
 sub class { 'Google::RestApi' }
@@ -11,36 +13,46 @@ sub startup : Tests(startup => 1) {
   use_ok $self->class();
 }
 
-sub constructor : Tests(8) {
+sub constructor : Tests(9) {
   my $self = shift;
 
   my $class = $self->class();
   can_ok $class, 'new';
 
-  throws_ok sub { $class->new(
-    client_id     => 'x',
-    client_secret => 'x',
-    token_file    => 'x',
-  ) }, qr/Token file not found/, 'Bad token file should fail';
+  my %auth = (
+    auth => {
+      class         => 'OAuth2Client',
+      client_id     => 'x',
+      client_secret => 'x',
+      token_file    => 'x',
+    },
+  );
+
+  my $api;
+  lives_ok sub { $api = $class->new(%{ dclone(\%auth) }) }, 'Constructor with bad token file should succeed';
+  throws_ok sub { $api->auth()->token_file() }, qr/Token file not found/, 'Bad token file should fail';
+
+  $auth{auth}->{token_file} = token_file();
+  $api = $class->new(%{ dclone(\%auth) });
+  lives_ok sub { $api->auth()->token_file() }, 'Proper token file should be found';
 
   throws_ok sub { $class->new(config_file => 'x'); },
     qr/Unable to load/, 'Bad config file should fail';
 
-  throws_ok sub { $class->new(
-    config_file => config_file(),
-    token_file  => 'x',
-  ), }, qr/Token file not found/, 'Overridden token file should fail';
-
-  ok my $api = $class->new(config_file => config_file()),
+  ok $api = $class->new(config_file => config_file()),
     'Constructor from config_file should succeed';
   isa_ok $api, $class, '... and the object it returns';
 
-  ok $api = $class->new(
-    client_id     => 'x',
-    client_secret => 'x',
-    token_file    => token_file(),
-  ), 'Constructor from named args should succeed';
-  isa_ok $api, $class, '... and the object it returns';
+  %auth = (
+    auth => {
+      class        => 'ServiceAccount',
+      account_file => 'x',
+      scope        => ['x'],
+    },
+  );
+  
+  lives_ok sub { $api = $class->new(%{ dclone(\%auth) }) }, 'Constructor with bad account file should succeed';
+  throws_ok sub { $api->auth()->account_file() }, qr/Service account file not found/, 'Bad account file should fail';
 
   return;
 }

--- a/t/unit/Test/Google/RestApi.pm
+++ b/t/unit/Test/Google/RestApi.pm
@@ -30,7 +30,7 @@ sub constructor : Tests(9) {
 
   my $api;
   lives_ok sub { $api = $class->new(%{ dclone(\%auth) }) }, 'Constructor with bad token file should succeed';
-  throws_ok sub { $api->auth()->token_file() }, qr/Token file not found/, 'Bad token file should fail';
+  throws_ok sub { $api->auth()->token_file() }, qr/not found or is not readable/, 'Bad token file should fail';
 
   $auth{auth}->{token_file} = token_file();
   $api = $class->new(%{ dclone(\%auth) });
@@ -50,9 +50,9 @@ sub constructor : Tests(9) {
       scope        => ['x'],
     },
   );
-  
+
   lives_ok sub { $api = $class->new(%{ dclone(\%auth) }) }, 'Constructor with bad account file should succeed';
-  throws_ok sub { $api->auth()->account_file() }, qr/Service account file not found/, 'Bad account file should fail';
+  throws_ok sub { $api->auth()->account_file() }, qr/not found or is not readable/, 'Bad account file should fail';
 
   return;
 }

--- a/t/unit/Test/Mock/RestApi.pm
+++ b/t/unit/Test/Mock/RestApi.pm
@@ -8,9 +8,12 @@ use Test::MockObject::Extends;
  
 sub new {
   my $self = RestApi->new(
-    client_id     => 'mocked_client_id',
-    client_secret => 'mocked_client_secret',
-    token_file    => $0,
+    auth => {
+      class         => 'OAuth2Client',
+      client_id     => 'mocked_client_id',
+      client_secret => 'mocked_client_secret',
+      token_file    => $0,
+    },
   );
   $self = Test::MockObject::Extends->new($self);
   $self->mock('token', sub { 'mocked_token'; });


### PR DESCRIPTION
Redesigned for multiple authorization mechanisms. All auth mechs should be under Google::RestApi::Auth::* and derived from Google::RestApi::Auth.pm. The derived classes should supply either 'headers' or 'params' to the RestApi module when necessary. Reworked the config files for RestApi and auth mech objects to allow either file config or flat hash. Added preliminary support for Google Service accounts based on contributions from user qorron.