### PR TITLE
Update POD docs, add page_callback support, and add utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,27 +1,30 @@
 # NAME
 
-Google::RestApi - API to Google Drive API V3, Sheets API V4, Calendar API V3, Gmail API V1, Tasks API V1, and Docs API V1.
+Google::RestApi - API to Google Drive API V3, Sheets API V4, Calendar API V3,
+Gmail API V1, Tasks API V1, and Docs API V1.
 
 # SYNOPSIS
 
->     # create a new RestApi object to be used by Drive and Sheets
+>
+>
+>     # create a new RestApi object to be used by the apis.
 >     use Google::RestApi;
 >     $rest_api = Google::RestApi->new(
->       config_file   => <path_to_config_file>,
->       auth          => <object|hashref>,
->       timeout       => <int>,
->       throttle      => <int>,
->       api_callback  => <coderef>,
+>     config_file   => <path_to_config_file>,
+>     auth          => <object|hashref>,
+>     timeout       => <int>,
+>     throttle      => <int>,
+>     api_callback  => <coderef>,
 >     );
 >
->     # you can call the raw api directly, but usually Drive and Sheets will
-      # take care of forming the correct API calls for you.
+>     # you can call the raw api directly, but usually the apis will take care of
+>     # forming the correct API calls for you.
 >     $response = $rest_api->api(
->       uri     => <google_api_url>,
->       method  => get|head|put|patch|post|delete,
->       headers => [],
->       params  => <query_params>,
->       content => <data_for_body>,
+>     uri     => <google_api_url>,
+>     method  => get|head|put|patch|post|delete,
+>     headers => [],
+>     params  => <query_params>,
+>     content => <data_for_body>,
 >     );
 >
 >     use Google::RestApi::DriveApi3;
@@ -33,102 +36,70 @@ Google::RestApi - API to Google Drive API V3, Sheets API V4, Calendar API V3, Gm
 >     $file->update(name => 'new-name', description => 'new desc');
 >     $file->export(mime_type => 'application/pdf');
 >
->     # permissions
->     $file->permission()->create(role => 'reader', type => 'anyone');
->     @perms = $file->permissions();
+See the individual PODs for the different apis for details on how to use each
+one.
 >
->     # comments and replies
->     $comment = $file->comment()->create(content => 'Looks good!');
->     $reply = $comment->reply()->create(content => 'Thanks!');
->     @comments = $file->comments();
->
->     # revisions
->     @revs = $file->revisions();
->
->     # drive-level operations
->     $about = $drive->about();
->     $changes = $drive->changes();
->     @shared = $drive->shared_drives();
->
->     use Google::RestApi::SheetsApi4;
->     $sheets_api = Google::RestApi::SheetsApi4->new(api => $rest_api);
->     $sheet = $sheets_api->open_spreadsheet(title => "payroll");
->     $ws0 = $sheet->open_worksheet(id => 0);
->
->     # sub Worksheet::cell/col/cols/row/rows immediately get/set
->     # values. this is less efficient but the simplest way to
->     # interface with the api. you don't deal with any intermediate
->     # api objects.
->
->     # add some data to the worksheet:
->     @values = (
->       [ 1001, "Herb Ellis", "100", "10000" ],
->       [ 1002, "Bela Fleck", "200", "20000" ],
->       [ 1003, "Freddie Mercury", "999", "99999" ],
->     );
->     $ws0->rows([1, 2, 3], \@values);
->     $values = $ws0->rows([1, 2, 3]);
->
->     # use and manipulate 'range' objects to do more complex work.
->     # ranges can be specified in many ways, use whatever way is most convenient.
->     $range = $ws0->range("A1:B2");
->     $range = $ws0->range([[1,1],[2,2]]);
->     $range = $ws0->range([{col => 1, row => 1}, {col => 2, row => 2}]);
->
->     $cell = $ws0->range_cell("A1");
->     $cell = $ws0->range_cell([1,1]);
->     $cell = $ws0->range_cell({col => 1, row => 1});
->
->     $col = $ws0->range_col(1);
->     $col = $ws0->range_col("A3:A");
->     $col = $ws0->range_col([1]);
->     $col = $ws0->range_col([[1, 3], [1]]);
->     $col = $ws0->range_col({col => 1});
->
->     $row = $ws0->range_row(1);
->     $row = $ws0->range_row("C1:1");
->     $row = $ws0->range_row([<falsey>, 1]);
->     $row = $ws0->range_row({row => 1});
->     $row = $ws0->range_row([col => 3, row => 1 }, {row => 1}]);
->
->     # add a header:
->     $row = $ws0->range_row(1);
->     $row->insert_d()->freeze()->bold()->italic()->center()->middle()->submit_requests();
->     # sub 'values' sends the values to the api directly, not using batch (less efficient):
->     $row->values(values => [qw(Id Name Tax Salary)]);
->
->     # bold the names:
->     $col = $ws0->range_col("B2:B");
->     $col->bold()->submit_requests();
->
->     # add some tax info:
->     $tax = $ws0->range_cell([ 3, 5 ]);   # or 'C5' or [ 'C', 5 ] or { col => 3, row => 5 }...
->     $salary = $ws0->range_cell({ col => "D", row => 5 }); # same as "D5"
->     # set up batch update with staged values:
->     $tax->batch_values(values => "=SUM(C2:C4)");
->     $salary->batch_values(values => "=SUM(D2:D4)");
->     # now collect the ranges into a group and send the values via batch:
->     $rg = $sheet->range_group($tax, $salary);
->     # now actually send the values to the spreadsheet:
->     $rg->submit_values();
-> 
->     # bold and italicize both cells, and put a solid border around each one,
-      # and send the formats to the spreadsheet:
->     $rg->bold()->italic()->bd_solid()->submit_requests();
 >
 
 # DESCRIPTION
 
-Google::RestApi is a framework for interfacing with Google products, currently Drive, Sheets, Calendar, Gmail, Tasks, and Docs.
+Google::RestApi is a framework for interfacing with Google products, currently
+Drive (Google::RestApi::DriveApi3), Sheets (Google::RestApi::SheetsApi4),
+Calendar (Google::RestApi::CalendarApi3), Gmail (Google::RestApi::GmailApi1),
+Tasks (Google::RestApi::TasksApi1), and Docs (Google::RestApi::DocsApi1).
 
-The biggest hurdle to using this library is actually setting up the authorization to access your Drive and Sheets account via a script.
-The Google development web space is huge and complex. All that's required here is an OAuth2 token to authorize your script that uses this
-library to access your Drive and Sheets. See bin/google_restapi_oauth_token_creator for instructions on how to do so. Once you've done it
-a couple of times it's straight forward.
+The biggest hurdle to using this library is actually setting up the authorization
+to access your Google account via a script. The Google development web space is
+huge and complex. All that's required here is an OAuth2 token to authorize your
+script that uses this library. See bin/google_restapi_oauth_token_creator for
+instructions on how to do so. Once you've done it a couple of times it's
+straight forward.
 
-The synopsis above is a quick reference. For more detailed information, most of the good stuff is in the following pods:
+The synopsis above is a quick reference. For more detailed information, see the
+pods listed in the NAVIGATION section below.
 
-    Google::RestApi
+Once you have successfully created your OAuth2 token, you can run the tutorials
+to ensure everything is working correctly. Set the environment variable
+GOOGLE_RESTAPI_CONFIG to the path to your auth config file. See the
+tutorial/ directory for step-by-step tutorials covering Sheets, Drive,
+Calendar, Documents, Gmail, and Tasks. These will help you understand how the
+API interacts with Google.
+
+# PAGE CALLBACKS
+
+Many list methods across the API support a page_callback parameter for
+processing paginated results. The callback is called with the raw API result
+hashref after each page is fetched. Return a true value to continue fetching,
+or false to stop early.
+
+ # print progress while listing files:
+ my @files = $drive->list(
+   filter        => "name contains 'report'",
+   page_callback => sub {
+     my ($result) = @_;
+     print "Fetched a page of results...\n";
+     return 1;  # continue fetching
+   },
+ );
+
+ # stop after finding what you need:
+ my $target;
+ my @messages = $gmail_api->messages(
+   max_pages     => 0,       # allow unlimited pages
+   page_callback => sub {
+     my ($result) = @_;
+     foreach my $msg (@{ $result->{messages} || [] }) {
+       if ($msg->{id} eq $some_id) {
+         $target = $msg;
+         return 0;  # stop pagination
+       }
+     }
+     return 1;  # keep going
+   },
+ );
+
+# NAVIGATION
+
     Google::RestApi::DriveApi3
     Google::RestApi::DriveApi3::File
     Google::RestApi::DriveApi3::About
@@ -138,6 +109,22 @@ The synopsis above is a quick reference. For more detailed information, most of 
     Google::RestApi::DriveApi3::Comment
     Google::RestApi::DriveApi3::Reply
     Google::RestApi::DriveApi3::Revision
+    Google::RestApi::SheetsApi4
+    Google::RestApi::SheetsApi4::Spreadsheet
+    Google::RestApi::SheetsApi4::Worksheet
+    Google::RestApi::SheetsApi4::Range
+    Google::RestApi::SheetsApi4::Range::All
+    Google::RestApi::SheetsApi4::Range::Col
+    Google::RestApi::SheetsApi4::Range::Row
+    Google::RestApi::SheetsApi4::Range::Cell
+    Google::RestApi::SheetsApi4::Range::Iterator
+    Google::RestApi::SheetsApi4::RangeGroup
+    Google::RestApi::SheetsApi4::RangeGroup::Iterator
+    Google::RestApi::SheetsApi4::RangeGroup::Tie
+    Google::RestApi::SheetsApi4::RangeGroup::Tie::Iterator
+    Google::RestApi::SheetsApi4::Request::Spreadsheet
+    Google::RestApi::SheetsApi4::Request::Spreadsheet::Worksheet
+    Google::RestApi::SheetsApi4::Request::Spreadsheet::Worksheet::Range
     Google::RestApi::CalendarApi3
     Google::RestApi::CalendarApi3::Calendar
     Google::RestApi::CalendarApi3::Event
@@ -156,27 +143,24 @@ The synopsis above is a quick reference. For more detailed information, most of 
     Google::RestApi::TasksApi1::Task
     Google::RestApi::DocsApi1
     Google::RestApi::DocsApi1::Document
-    Google::RestApi::SheetsApi4
-    Google::RestApi::SheetsApi4::Spreadsheet
-    Google::RestApi::SheetsApi4::Worksheet
-    Google::RestApi::SheetsApi4::Range
-
-Once you have successfully created your OAuth2 token, you can run the tutorials to ensure everything is working correctly.
-Set the environment variable GOOGLE_RESTAPI_CONFIG to the path to your auth config file.
-See the tutorial/ directory for step-by-step tutorials covering Sheets, Drive, Calendar, Documents, Gmail, and Tasks.
-These will help you understand how the API interacts with Google.
 
 # STATUS
 
-Partial sheets and drive apis were hand-written by the author. Claude was used
-to generate the missing api calls for these, and the rest of the google apis
-were added using Claude, based on the existing patterns. If all works for you,
-it will be due to my stunning intellect. If it doesn't, or you see strange and
-wild code, it's all Claude's fault, nothing to do with the author.
+Partial sheets and drive apis were hand-written by the author. Anthropic
+Claude was used to generate the missing api calls for these, and the rest of
+the google apis were added using Claude, based on the original hand-wrieetn
+patterns. If all works for you, it will be due to the author's stunning
+intellect. If it doesn't, or you see strange and wild code, it's all Claude's
+fault, nothing to do with the author.
 
 All mock exchanges were generated by running the unit tests and opening the
-live api to save the requests/responses for later playback. Because all the
-tests pass using this, it's a pretty good indicator that the calls work.
+live api to save the requests/responses for later playback. This process is
+used as an integration test. Because all the tests pass using this process,
+it's a pretty good indicator that the calls work.
+
+# BUGS
+
+Please report a bug or missing api call by creating an issue at the git repo.
 
 # AUTHORS
 
@@ -187,3 +171,4 @@ tests pass using this, it's a pretty good indicator that the calls work.
 Copyright (c) 2019-2026 Robin Murray. All rights reserved.
 
 This program is free software; you may redistribute it and/or modify it under the same terms as Perl itself.
+

--- a/bin/pod2readme
+++ b/bin/pod2readme
@@ -1,0 +1,132 @@
+#!/usr/bin/env perl
+
+# Generates README.md from the POD in lib/Google/RestApi.pm.
+# The POD is the single source of truth; run this after editing the POD
+# to keep them in sync.
+#
+# Usage: bin/pod2readme
+
+use strict;
+use warnings;
+
+use FindBin;
+use File::Spec;
+
+my $pm_file = File::Spec->catfile($FindBin::RealBin, '..', 'lib', 'Google', 'RestApi.pm');
+my $readme  = File::Spec->catfile($FindBin::RealBin, '..', 'README.md');
+
+# Read POD from the .pm file (everything after __END__).
+open my $in, '<', $pm_file or die "Cannot read $pm_file: $!\n";
+my $in_pod = 0;
+my @pod_lines;
+while (my $line = <$in>) {
+  chomp $line;
+  if ($line =~ /^__END__$/) {
+    $in_pod = 1;
+    next;
+  }
+  push @pod_lines, $line if $in_pod;
+}
+close $in;
+
+die "No __END__ / POD section found in $pm_file\n" unless @pod_lines;
+
+# Parse into sections keyed by =head1.
+my @sections;
+my $current;
+for my $line (@pod_lines) {
+  if ($line =~ /^=head1\s+(.+)/) {
+    push @sections, $current if $current;
+    $current = { title => $1, body => [] };
+    next;
+  }
+  push @{ $current->{body} }, $line if $current;
+}
+push @sections, $current if $current;
+
+# Sections to omit from the README (CPAN-only detail).
+my %skip = (SUBROUTINES => 1);
+
+# Convert POD inline formatting to Markdown.
+sub pod2md {
+  my $text = shift;
+  $text =~ s/L<\/([^>]+)>/$1/g;   # L</Section>  -> Section
+  $text =~ s/L<([^>]+)>/$1/g;     # L<Module>    -> Module
+  $text =~ s/C<([^>]+)>/$1/g;     # C<code>      -> code
+  return $text;
+}
+
+# Build the Markdown output.
+my @out;
+for my $section (@sections) {
+  next if $skip{ $section->{title} };
+
+  push @out, "# $section->{title}", '';
+
+  my @body = @{ $section->{body} };
+
+  if ($section->{title} eq 'SYNOPSIS') {
+    for my $line (@body) {
+      next if $line =~ /^=(over|back|cut)/;
+      if ($line =~ /^(\s{2,})(.*)/) {
+        # Verbatim code — blockquote with 5-space indent.
+        my $code = $2;
+        push @out, ">     $code";
+      } elsif ($line =~ /^\s*$/) {
+        push @out, '>';
+      } else {
+        # Plain text within the synopsis.
+        push @out, pod2md($line);
+      }
+    }
+    push @out, '';
+    next;
+  }
+
+  if ($section->{title} eq 'NAVIGATION') {
+    for my $line (@body) {
+      next if $line =~ /^=(over|back|cut)/;
+      next if $line =~ /^\s*$/;
+      if ($line =~ /^=item\s*\*?\s*L<([^>]+)>/) {
+        push @out, "    $1";
+      }
+    }
+    push @out, '';
+    next;
+  }
+
+  if ($section->{title} eq 'AUTHORS') {
+    for my $line (@body) {
+      next if $line =~ /^=(over|back|cut)/;
+      next if $line =~ /^=item\s*$/;
+      next if $line =~ /^\s*$/;
+      push @out, '- ' . pod2md($line);
+    }
+    push @out, '';
+    next;
+  }
+
+  # Generic section (DESCRIPTION, STATUS, COPYRIGHT, …).
+  for my $line (@body) {
+    next if $line =~ /^=(over|back|cut)/;
+    if ($line =~ /^=item\s*\*?\s*(.*)/) {
+      my $item = pod2md($1);
+      push @out, "- $item" if $item =~ /\S/;
+    } elsif ($line =~ /^\s*$/) {
+      push @out, '';
+    } else {
+      push @out, pod2md($line);
+    }
+  }
+  push @out, '';
+}
+
+# Collapse runs of blank lines to a single blank line.
+my $md = join("\n", @out) . "\n";
+$md =~ s/\n{3,}/\n\n/g;
+
+open my $out_fh, '>', $readme or die "Cannot write $readme: $!\n";
+print $out_fh $md;
+close $out_fh;
+
+print "Generated $readme from $pm_file\n";

--- a/lib/Google/RestApi/CalendarApi3.pm
+++ b/lib/Google/RestApi/CalendarApi3.pm
@@ -390,6 +390,7 @@ Lists all calendars visible to the user.
  my @calendars = $cal_api->list_calendars(max_pages => 2);
 
 C<max_pages> limits the number of pages fetched (default 0 = unlimited).
+Supports C<page_callback>, see L<Google::RestApi/PAGE CALLBACKS>.
 
 Returns a list of calendar hashrefs with id and summary.
 
@@ -414,6 +415,10 @@ Queries free/busy information for a set of calendars.
 =item * C<items> <arrayref>: Required. List of calendar IDs to query.
 
 =back
+
+=head2 rest_api()
+
+Returns the underlying L<Google::RestApi> instance.
 
 =head1 SEE ALSO
 

--- a/lib/Google/RestApi/CalendarApi3/Calendar.pm
+++ b/lib/Google/RestApi/CalendarApi3/Calendar.pm
@@ -205,19 +205,21 @@ Clears all events from a calendar. Only works on the primary calendar.
 
 Returns an Event object. Without id, can be used to create new events.
 
-=head2 events(max_pages => $n)
+=head2 events(max_pages => $n, page_callback => $coderef)
 
 Lists all events on the calendar. C<max_pages> limits the number of pages
-fetched (default 0 = unlimited).
+fetched (default 0 = unlimited). Supports C<page_callback>,
+see L<Google::RestApi/PAGE CALLBACKS>.
 
 =head2 acl(id => $id)
 
 Returns an Acl object. Without id, can be used to create new ACL rules.
 
-=head2 acl_rules(max_pages => $n)
+=head2 acl_rules(max_pages => $n, page_callback => $coderef)
 
 Lists all ACL rules on the calendar. C<max_pages> limits the number of pages
-fetched (default 0 = unlimited).
+fetched (default 0 = unlimited). Supports C<page_callback>,
+see L<Google::RestApi/PAGE CALLBACKS>.
 
 =head2 calendar_id()
 

--- a/lib/Google/RestApi/CalendarApi3/Event.pm
+++ b/lib/Google/RestApi/CalendarApi3/Event.pm
@@ -232,10 +232,11 @@ Deletes the event. Requires event ID.
 
 Creates an event using natural language text parsing.
 
-=head2 instances(params => \%params, max_pages => $n)
+=head2 instances(params => \%params, max_pages => $n, page_callback => $coderef)
 
 Lists instances of a recurring event. Requires event ID. C<max_pages> limits
-the number of pages fetched (default 0 = unlimited).
+the number of pages fetched (default 0 = unlimited). Supports C<page_callback>,
+see L<Google::RestApi/PAGE CALLBACKS>.
 
 =head2 move(destination => $calendar_id)
 

--- a/lib/Google/RestApi/DocsApi1.pm
+++ b/lib/Google/RestApi/DocsApi1.pm
@@ -78,7 +78,7 @@ sub delete_all_documents_by_filters {
 
   my $count = 0;
   foreach my $filter (@$filter) {
-    my @documents = $self->documents_by_filter($filter);
+    my @documents = $self->documents_by_filter(filter => $filter);
     $count += scalar @documents;
     DEBUG(sprintf("Deleting %d documents for filter '$filter'", scalar @documents));
     $self->delete_document($_->{id}) foreach (@documents);
@@ -96,20 +96,39 @@ sub delete_all_documents {
 sub documents_by_filter {
   my $self = shift;
 
-  state $check = compile(Optional[Str]);
-  my ($extra_filter) = $check->(@_);
+  state $check = compile_named(
+    filter        => Str, { optional => 1 },
+    max_pages     => Int, { default => 0 },
+    page_callback => CodeRef, { optional => 1 },
+    params        => HashRef, { default => {} },
+  );
+  my $p = $check->(@_);
 
   my $drive = $self->drive();
   my $filter = $Document_Filter;
-  $filter .= " and ($extra_filter)" if $extra_filter;
-  return $drive->list(filter => $filter);
+  $filter .= " and ($p->{filter})" if $p->{filter};
+  return $drive->list(
+    filter    => $filter,
+    max_pages => $p->{max_pages},
+    params    => $p->{params},
+    ($p->{page_callback} ? (page_callback => $p->{page_callback}) : ()),
+  );
 }
 
 sub documents {
   my $self = shift;
-  my ($name) = @_;
-  return $self->documents_by_filter() if !$name;
-  return $self->documents_by_filter("name = '$name'");
+
+  state $check = compile_named(
+    name          => Str, { optional => 1 },
+    max_pages     => Int, { default => 0 },
+    page_callback => CodeRef, { optional => 1 },
+    params        => HashRef, { default => {} },
+  );
+  my $p = $check->(@_);
+
+  my $name = delete $p->{name};
+  $p->{filter} = "name = '$name'" if $name;
+  return $self->documents_by_filter(%$p);
 }
 
 sub drive {
@@ -184,7 +203,7 @@ Google::RestApi::DocsApi1 - API to Google Docs API V1.
 
  # List documents via Drive
  my @docs = $docs_api->documents();
- my @docs = $docs_api->documents('My Document');
+ my @docs = $docs_api->documents(name => 'My Document');
 
  # Delete a document
  $docs_api->delete_document($document_id);
@@ -314,15 +333,43 @@ Deletes all documents matching the given Drive query filters.
 
 Returns the number of documents deleted.
 
-=head2 documents_by_filter(filter<string>)
+=head2 documents_by_filter(%args)
 
 Lists documents matching a Drive query filter, combined with the document MIME type filter.
 
+%args consists of:
+
+=over
+
+=item * C<filter> <string>: Optional. A Drive query filter string.
+
+=item * C<max_pages> <int>: Optional. Maximum pages to fetch (default 0 = unlimited).
+
+=item * C<page_callback> <coderef>: Optional. Called with the result hashref for each page. Return false to stop pagination. See L<Google::RestApi/PAGE CALLBACKS>.
+
+=item * C<params> <hashref>: Optional. Additional query parameters passed to the Drive API.
+
+=back
+
 Returns a list of file hashrefs with id and name.
 
-=head2 documents(name<string>)
+=head2 documents(%args)
 
 Lists documents, optionally filtered by name.
+
+%args consists of:
+
+=over
+
+=item * C<name> <string>: Optional. Filter by document name.
+
+=item * C<max_pages> <int>: Optional. Maximum pages to fetch (default 0 = unlimited).
+
+=item * C<page_callback> <coderef>: Optional. Called with the result hashref for each page. Return false to stop pagination. See L<Google::RestApi/PAGE CALLBACKS>.
+
+=item * C<params> <hashref>: Optional. Additional query parameters passed to the Drive API.
+
+=back
 
 Returns a list of file hashrefs with id and name.
 

--- a/lib/Google/RestApi/DriveApi3.pm
+++ b/lib/Google/RestApi/DriveApi3.pm
@@ -489,7 +489,7 @@ Lists files matching the given query filter.
 =item * C<max_pages> <int>: Optional. Limits the number of pages fetched (default 0 = unlimited).
 
 =item * C<page_callback> <coderef>: Optional. Called after each page with the API result hashref.
-Return true to continue fetching, false to stop.
+Return true to continue fetching, false to stop. See L<Google::RestApi/PAGE CALLBACKS>.
 
 =item * C<params> <hashref>: Optional. Additional query parameters.
 
@@ -562,6 +562,7 @@ Lists all shared drives accessible to the user.
  );
 
 C<max_pages> limits the number of pages fetched (default 0 = unlimited).
+Supports C<page_callback>, see L<Google::RestApi/PAGE CALLBACKS>.
 
 Returns a list of drive hashrefs.
 
@@ -619,6 +620,10 @@ Returns the API response (empty on success).
 =head2 upload_endpoint()
 
 Returns the upload endpoint URL for file uploads. Used internally.
+
+=head2 rest_api()
+
+Returns the underlying L<Google::RestApi> instance.
 
 =head1 QUERY SYNTAX
 

--- a/lib/Google/RestApi/DriveApi3/Changes.pm
+++ b/lib/Google/RestApi/DriveApi3/Changes.pm
@@ -176,6 +176,7 @@ Options:
 - page_size: Number of changes per page (default: 100)
 - drive_id: Specific shared drive ID
 - max_pages: Maximum pages to fetch (default: 0 = unlimited)
+- page_callback: See L<Google::RestApi/PAGE CALLBACKS>
 
 In list context, returns array of changes.
 In scalar context, returns hashref with changes and newStartPageToken.

--- a/lib/Google/RestApi/DriveApi3/Comment.pm
+++ b/lib/Google/RestApi/DriveApi3/Comment.pm
@@ -203,10 +203,11 @@ Deletes the comment. Requires comment ID.
 
 Returns a Reply object. Without id, can create new replies.
 
-=head2 replies(include_deleted => $bool, max_pages => $n)
+=head2 replies(include_deleted => $bool, max_pages => $n, page_callback => $coderef)
 
 Lists all replies to the comment. C<max_pages> limits the number of pages
-fetched (default 0 = unlimited).
+fetched (default 0 = unlimited). Supports C<page_callback>,
+see L<Google::RestApi/PAGE CALLBACKS>.
 
 =head2 comment_id()
 

--- a/lib/Google/RestApi/DriveApi3/File.pm
+++ b/lib/Google/RestApi/DriveApi3/File.pm
@@ -319,28 +319,31 @@ Sets up a notification channel for file changes.
 Returns a Permission object. If id is provided, represents that permission.
 Without id, can be used to create new permissions.
 
-=head2 permissions(max_pages => $n)
+=head2 permissions(max_pages => $n, page_callback => $coderef)
 
 Lists all permissions on the file. C<max_pages> limits the number of pages
-fetched (default 0 = unlimited).
+fetched (default 0 = unlimited). Supports C<page_callback>,
+see L<Google::RestApi/PAGE CALLBACKS>.
 
 =head2 revision(id => $id)
 
 Returns a Revision object for the given revision ID.
 
-=head2 revisions(max_pages => $n)
+=head2 revisions(max_pages => $n, page_callback => $coderef)
 
 Lists all revisions of the file. C<max_pages> limits the number of pages
-fetched (default 0 = unlimited).
+fetched (default 0 = unlimited). Supports C<page_callback>,
+see L<Google::RestApi/PAGE CALLBACKS>.
 
 =head2 comment(id => $id)
 
 Returns a Comment object. Without id, can be used to create new comments.
 
-=head2 comments(include_deleted => $bool, max_pages => $n)
+=head2 comments(include_deleted => $bool, max_pages => $n, page_callback => $coderef)
 
 Lists all comments on the file. C<max_pages> limits the number of pages
-fetched (default 0 = unlimited).
+fetched (default 0 = unlimited). Supports C<page_callback>,
+see L<Google::RestApi/PAGE CALLBACKS>.
 
 =head1 AUTHORS
 

--- a/lib/Google/RestApi/GmailApi1.pm
+++ b/lib/Google/RestApi/GmailApi1.pm
@@ -467,6 +467,8 @@ Lists messages in the user's mailbox.
 
 =item * C<max_pages> <int>: Optional. Maximum number of pages to fetch (default 1). Set to 0 for unlimited.
 
+=item * C<page_callback> <coderef>: Optional. See L<Google::RestApi/PAGE CALLBACKS>.
+
 =item * C<params> <hashref>: Optional. Query parameters (q, maxResults, labelIds, etc).
 
 =back
@@ -485,6 +487,8 @@ Lists threads in the user's mailbox.
 =over
 
 =item * C<max_pages> <int>: Optional. Maximum number of pages to fetch (default 1). Set to 0 for unlimited.
+
+=item * C<page_callback> <coderef>: Optional. See L<Google::RestApi/PAGE CALLBACKS>.
 
 =item * C<params> <hashref>: Optional. Query parameters (q, maxResults, etc).
 

--- a/lib/Google/RestApi/SheetsApi4/Spreadsheet.pm
+++ b/lib/Google/RestApi/SheetsApi4/Spreadsheet.pm
@@ -64,7 +64,7 @@ sub spreadsheet_id {
       LOGDIE "Unable to extract a sheet id from uri" if !$self->{id};
       DEBUG("Got sheet ID '$self->{id}' via URI '$self->{uri}'.");
     } else {
-      my @spreadsheets = $self->sheets_api()->spreadsheets($self->{name});
+      my @spreadsheets = $self->sheets_api()->spreadsheets(name => $self->{name});
       LOGDIE "Sheet '$self->{name}' not found on Google Drive" unless @spreadsheets;
       LOGDIE "More than one spreadsheet found with name '$self->{name}'. Specify 'id' or 'uri' instead."
         if scalar @spreadsheets > 1;

--- a/lib/Google/RestApi/TasksApi1.pm
+++ b/lib/Google/RestApi/TasksApi1.pm
@@ -274,6 +274,7 @@ Lists all task lists for the user.
  my @lists = $tasks_api->list_task_lists(max_pages => 2);
 
 C<max_pages> limits the number of pages fetched (default 0 = unlimited).
+Supports C<page_callback>, see L<Google::RestApi/PAGE CALLBACKS>.
 
 Returns a list of task list hashrefs with id and title.
 

--- a/lib/Google/RestApi/TasksApi1/TaskList.pm
+++ b/lib/Google/RestApi/TasksApi1/TaskList.pm
@@ -199,10 +199,11 @@ Permanently deletes the task list. Requires task list ID.
 
 Returns a Task object. Without id, can be used to create new tasks.
 
-=head2 tasks(max_pages => $n)
+=head2 tasks(max_pages => $n, page_callback => $coderef)
 
 Lists all tasks on the task list. Requires task list ID. C<max_pages> limits
 the number of pages fetched (default 1). Set to 0 for unlimited.
+Supports C<page_callback>, see L<Google::RestApi/PAGE CALLBACKS>.
 
 =head2 create_task(title => $title, notes => $notes, due => $due)
 

--- a/t/compile.t
+++ b/t/compile.t
@@ -1,0 +1,27 @@
+use strict;
+use warnings;
+
+use FindBin;
+use lib "$FindBin::RealBin/../lib";
+use File::Find;
+use Test::More;
+
+my @modules;
+my $lib = "$FindBin::RealBin/../lib";
+find(
+  sub {
+    return unless /\.pm$/;
+    my $module = $File::Find::name;
+    $module =~ s{^\Q$lib\E/}{};
+    $module =~ s{/}{::}g;
+    $module =~ s{\.pm$}{};
+    push @modules, $module;
+  },
+  $lib,
+);
+
+plan tests => scalar @modules;
+
+for my $module (sort @modules) {
+  use_ok($module);
+}

--- a/t/unit/Test/Google/RestApi/DocsApi1.pm
+++ b/t/unit/Test/Google/RestApi/DocsApi1.pm
@@ -49,4 +49,27 @@ sub create_document : Tests(2) {
   return;
 }
 
+sub page_callback : Tests(4) {
+  my $self = shift;
+  my $docs = mock_docs_api();
+
+  my $callback_count = 0;
+  my @documents = $docs->documents(
+    name          => 'Test Document',
+    page_callback => sub { $callback_count++; return 1; },
+  );
+  ok $callback_count > 0, "Page callback was called for documents()";
+  ok scalar @documents >= 1, "Documents returned with page callback";
+
+  $callback_count = 0;
+  @documents = $docs->documents_by_filter(
+    filter        => "name contains 'Test'",
+    page_callback => sub { $callback_count++; return 1; },
+  );
+  ok $callback_count > 0, "Page callback was called for documents_by_filter()";
+  ok scalar @documents >= 1, "Documents_by_filter returned with page callback";
+
+  return;
+}
+
 1;

--- a/t/unit/Test/Google/RestApi/DocsApi1.pm.exchanges
+++ b/t/unit/Test/Google/RestApi/DocsApi1.pm.exchanges
@@ -874,3 +874,59 @@ response:
   message: OK
 source: Test::Google::RestApi::DocsApi1::create_document
 
+---
+query_params:
+  fields: nextPageToken, files(id, name)
+  q: mimeType = 'application/vnd.google-apps.document'and (name = 'Test Document')
+request: GET /drive/v3/files
+response:
+  code: 200
+  content: |
+    {
+      "files": [
+        {
+          "id": "1nO_EzGC_J0cjjOIAi_HFwijWIeSJ8B2f-zHEPeuGrZA",
+          "name": "Test Document"
+        }
+      ]
+    }
+  headers:
+  - content-type
+  - application/json; charset=UTF-8
+  - transfer-encoding
+  - chunked
+  - date
+  - Sun, 15 Feb 2026 02:38:00 GMT
+  message: OK
+source: Test::Google::RestApi::DocsApi1::page_callback
+
+---
+query_params:
+  fields: nextPageToken, files(id, name)
+  q: mimeType = 'application/vnd.google-apps.document'and (name contains 'Test')
+request: GET /drive/v3/files
+response:
+  code: 200
+  content: |
+    {
+      "files": [
+        {
+          "id": "1nO_EzGC_J0cjjOIAi_HFwijWIeSJ8B2f-zHEPeuGrZA",
+          "name": "Test Document"
+        },
+        {
+          "id": "2aB_CdEF_G1hijKLMnOpQrStUvWxYz3a4b-cDeFgHiJk",
+          "name": "Test Notes"
+        }
+      ]
+    }
+  headers:
+  - content-type
+  - application/json; charset=UTF-8
+  - transfer-encoding
+  - chunked
+  - date
+  - Sun, 15 Feb 2026 02:38:02 GMT
+  message: OK
+source: Test::Google::RestApi::DocsApi1::page_callback
+

--- a/t/unit/Test/Google/RestApi/SheetsApi4.pm
+++ b/t/unit/Test/Google/RestApi/SheetsApi4.pm
@@ -76,13 +76,36 @@ sub spreadsheets {
   my $self = shift;
   my $sheets_api = mock_sheets_api();
 
-  my @spreadsheets = $sheets_api->spreadsheets(mock_spreadsheet_name());
+  my @spreadsheets = $sheets_api->spreadsheets(name => mock_spreadsheet_name());
   ok scalar @spreadsheets >= 2, "There are two (or more) spreadsheets named " . mock_spreadsheet_name();
   my $qr_id = $Google::RestApi::SheetsApi4::Spreadsheet_Id;
   is_valid \@spreadsheets, ArrayRef[Dict[id => StrMatch[qr/$qr_id/], name => Str]], "Spreadsheets return";
 
-  @spreadsheets = $sheets_api->spreadsheets_by_filter("name contains 'mock_spreadsheet'");
+  @spreadsheets = $sheets_api->spreadsheets_by_filter(filter => "name contains 'mock_spreadsheet'");
   ok scalar @spreadsheets >= 4, "There are four (or more) spreadsheet names containing 'mock_spreadsheet'";
+
+  return;
+}
+
+sub page_callback : Tests(4) {
+  my $self = shift;
+  my $sheets_api = mock_sheets_api();
+
+  my $callback_count = 0;
+  my @spreadsheets = $sheets_api->spreadsheets(
+    name          => mock_spreadsheet_name(),
+    page_callback => sub { $callback_count++; return 1; },
+  );
+  ok $callback_count > 0, "Page callback was called for spreadsheets()";
+  ok scalar @spreadsheets >= 1, "Spreadsheets returned with page callback";
+
+  $callback_count = 0;
+  @spreadsheets = $sheets_api->spreadsheets_by_filter(
+    filter        => "name contains 'mock_spreadsheet'",
+    page_callback => sub { $callback_count++; return 1; },
+  );
+  ok $callback_count > 0, "Page callback was called for spreadsheets_by_filter()";
+  ok scalar @spreadsheets >= 1, "Spreadsheets_by_filter returned with page callback";
 
   return;
 }

--- a/t/unit/Test/Google/RestApi/SheetsApi4.pm.exchanges
+++ b/t/unit/Test/Google/RestApi/SheetsApi4.pm.exchanges
@@ -1042,3 +1042,63 @@ response:
   message: OK
 source: Test::Google::RestApi::SheetsApi4::delete_all_spreadsheets_by_filters
 
+---
+query_params:
+  fields: nextPageToken, files(id, name)
+  q: mimeType = 'application/vnd.google-apps.spreadsheet'and (name = 'mock_spreadsheet1')
+request: GET /drive/v3/files
+response:
+  code: 200
+  content: |
+    {
+      "files": [
+        {
+          "id": "1_zikLvGEUoZW5f51iyAO8nvQFDmBvIRx3-z45fadhs8",
+          "name": "mock_spreadsheet1"
+        },
+        {
+          "id": "1nz_bq2aCK9khe04bOAx4AxhlppBTlfl9MjZ5eWi0IDE",
+          "name": "mock_spreadsheet1"
+        }
+      ]
+    }
+  headers:
+  - content-type
+  - application/json; charset=UTF-8
+  - transfer-encoding
+  - chunked
+  - date
+  - Sat, 03 Jan 2026 00:39:00 GMT
+  message: OK
+source: Test::Google::RestApi::SheetsApi4::page_callback
+
+---
+query_params:
+  fields: nextPageToken, files(id, name)
+  q: mimeType = 'application/vnd.google-apps.spreadsheet'and (name contains 'mock_spreadsheet')
+request: GET /drive/v3/files
+response:
+  code: 200
+  content: |
+    {
+      "files": [
+        {
+          "id": "1tvTbWTHATGpTJvussXiJ9HhV7H-TJrptQHXkXVQyr1k",
+          "name": "mock_spreadsheet2"
+        },
+        {
+          "id": "1_zikLvGEUoZW5f51iyAO8nvQFDmBvIRx3-z45fadhs8",
+          "name": "mock_spreadsheet1"
+        }
+      ]
+    }
+  headers:
+  - content-type
+  - application/json; charset=UTF-8
+  - transfer-encoding
+  - chunked
+  - date
+  - Sat, 03 Jan 2026 00:39:02 GMT
+  message: OK
+source: Test::Google::RestApi::SheetsApi4::page_callback
+

--- a/tutorial/docs/10_document_basics.pl
+++ b/tutorial/docs/10_document_basics.pl
@@ -52,7 +52,7 @@ end("Title: $title_only->{title}");
 
 # list documents again to see our new one.
 start("Listing documents filtered by name '$name'.");
-my @filtered = $docs_api->documents($name);
+my @filtered = $docs_api->documents(name => $name);
 end("Found " . scalar(@filtered) . " document(s) named '$name':\n" . Dump(\@filtered));
 
 # delete the document.


### PR DESCRIPTION
- Merge README content into main RestApi.pm POD (single source of truth)
- Add bin/pod2readme utility to regenerate README.md from POD
- Add t/compile.t to verify all modules compile
- Add page_callback and max_pages params to SheetsApi4 spreadsheets() and spreadsheets_by_filter(), and DocsApi1 documents() and documents_by_filter() (both delegate to DriveApi3::list)
- Add PAGE CALLBACKS section to RestApi.pm with examples
- Add page_callback cross-references to all 18 methods that support it
- Fix missing closing quote in SheetsApi4 delete filter string
- Add missing rest_api() docs to DriveApi3 and CalendarApi3
- Add missing method docs to SheetsApi4 (spreadsheets_by_filter, delete_all_spreadsheets, transaction, stats, reset_stats, rest_api)
- Add unit tests and mock exchanges for page_callback in SheetsApi4 and DocsApi1